### PR TITLE
New option `--plain-ui`: Support systems that only support plain output

### DIFF
--- a/internal/csv/csv.go
+++ b/internal/csv/csv.go
@@ -1,0 +1,32 @@
+package csv
+
+import (
+	"strings"
+
+	"github.com/magodo/pipeform/internal/state"
+)
+
+type Input struct {
+	RefreshInfos state.ResourceInfos
+	ApplyInfos   state.ResourceInfos
+}
+
+func ToCsv(input Input) []byte {
+	out := []string{
+		strings.Join([]string{
+			"Start Timestamp",
+			"End Timestamp",
+			"Stage",
+			"Action",
+			"Module",
+			"Resource Type",
+			"Resource Name",
+			"Resource Key",
+			"Status",
+			"Duration (sec)",
+		}, ","),
+	}
+	out = append(out, input.RefreshInfos.ToCsv("refresh")...)
+	out = append(out, input.ApplyInfos.ToCsv("apply")...)
+	return []byte(strings.Join(out, "\n"))
+}

--- a/internal/plainui/ui.go
+++ b/internal/plainui/ui.go
@@ -1,0 +1,262 @@
+package plainui
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/magodo/pipeform/internal/csv"
+	"github.com/magodo/pipeform/internal/log"
+	"github.com/magodo/pipeform/internal/reader"
+	"github.com/magodo/pipeform/internal/state"
+	"github.com/magodo/pipeform/internal/terraform/views"
+	"github.com/magodo/pipeform/internal/terraform/views/json"
+)
+
+type UIModel struct {
+	startTime time.Time
+	logger    *log.Logger
+	reader    reader.Reader
+	writer    io.Writer
+
+	refreshInfos state.ResourceInfos
+	applyInfos   state.ResourceInfos
+
+	totalCnt int
+	doneCnt  int
+
+	isEOF bool
+}
+
+func NewRuntimeModel(logger *log.Logger, reader reader.Reader, writer io.Writer, startTime time.Time) UIModel {
+	model := UIModel{
+		startTime: startTime,
+		logger:    logger,
+		reader:    reader,
+		writer:    writer,
+	}
+
+	return model
+}
+
+func (m *UIModel) Run() error {
+	for {
+		msg, err := m.reader.Next()
+		if err != nil {
+			if err == io.EOF {
+				m.isEOF = true
+				return nil
+			}
+			return err
+		}
+
+		var msgstr string
+		switch msg := msg.(type) {
+		case views.VersionMsg:
+			msgstr = msg.Message
+		case views.LogMsg:
+			kvs := []string{}
+			for k, v := range msg.KVs {
+				kvs = append(kvs, fmt.Sprintf("%s=%v", k, v))
+			}
+			msgstr = fmt.Sprintf("%s. %s", msg.Message, strings.Join(kvs, " "))
+		case views.DiagnosticsMsg:
+			msgstr = fmt.Sprintf("Summary: %s.", msg.Diagnostic.Summary)
+			if msg.Diagnostic.Detail != "" {
+				msgstr += fmt.Sprintf(" Detail: %s", msg.Diagnostic.Detail)
+			}
+			if msg.Level != "info" {
+				msgstr = fmt.Sprintf("[%s] %s", strings.ToUpper(msg.Level), msgstr)
+			}
+		case views.ResourceDriftMsg:
+			msgstr = msg.Message
+		case views.PlannedChangeMsg:
+			// Normally, we don't need to handle the PlannedChangeMsg here, as the ChangeSummaryMsg has all these information.
+			// The exception is that when apply with a plan file, there is no ChangeSummaryMsg sent from Terraform at this moment.
+			// (see: https://github.com/magodo/pipeform/issues/1)
+			// The counting here is a fallback logic to cover the case above. Otherwise, it will just be overwritten by ChangeSummaryMsg.
+			//
+			// TODO: Once https://github.com/hashicorp/terraform/pull/36245 merged, remove this part.
+			//
+			// Referencing the logic of terraform: internal/command/views/operation.go
+			// But we also count the "import"
+			switch msg.Change.Action {
+			case json.ActionCreate:
+				m.totalCnt++
+			case json.ActionDelete:
+				m.totalCnt++
+			case json.ActionUpdate:
+				m.totalCnt++
+			case json.ActionReplace:
+				m.totalCnt += 2
+			case json.ActionImport:
+				m.totalCnt++
+			}
+			msgstr = msg.Message
+
+		case views.ChangeSummaryMsg:
+			changes := msg.Changes
+			m.totalCnt = changes.Add + changes.Change + changes.Import + changes.Remove
+			msgstr = msg.Message
+
+		case views.OutputMsg:
+			outputs := []string{}
+			for name, o := range msg.Outputs {
+				if o.Action != "" {
+					continue
+				}
+				output := fmt.Sprintf("%s=%s", name, string(o.Value))
+				if o.Sensitive {
+					output += " (sensitive)"
+				}
+				outputs = append(outputs, output)
+			}
+			msgstr = fmt.Sprintf("%s. %s", msg.Message, strings.Join(outputs, " "))
+
+		case views.HookMsg:
+			switch hook := msg.Hook.(type) {
+			case json.RefreshStart:
+				res := &state.ResourceInfo{
+					Idx:             len(m.refreshInfos) + 1,
+					RawResourceAddr: hook.Resource,
+					Loc: state.ResourceInfoLocator{
+						Module:       hook.Resource.Module,
+						ResourceAddr: hook.Resource.Addr,
+						Action:       "refresh",
+					},
+					Status:    state.ResourceStatusStart,
+					StartTime: msg.TimeStamp,
+				}
+				m.refreshInfos = append(m.refreshInfos, res)
+				msgstr = msg.Message
+
+			case json.RefreshComplete:
+				loc := state.ResourceInfoLocator{
+					Module:       hook.Resource.Module,
+					ResourceAddr: hook.Resource.Addr,
+					Action:       "refresh",
+				}
+				status := state.ResourceStatusComplete
+				update := state.ResourceInfoUpdate{
+					Status:  &status,
+					Endtime: &msg.TimeStamp,
+				}
+				if m.refreshInfos.Update(loc, update) == nil {
+					m.logger.Error("RefreshComplete hook can't find the resource info", "module", hook.Resource.Module, "addr", hook.Resource.Addr, "action", "refresh")
+					break
+				}
+				msgstr = msg.Message
+
+			case json.OperationStart:
+				info := &state.ResourceInfo{
+					Idx:             len(m.applyInfos) + 1,
+					RawResourceAddr: hook.Resource,
+					Loc: state.ResourceInfoLocator{
+						Module:       hook.Resource.Module,
+						ResourceAddr: hook.Resource.Addr,
+						Action:       string(hook.Action),
+					},
+					Status:    state.ResourceStatusStart,
+					StartTime: msg.TimeStamp,
+				}
+				m.applyInfos = append(m.applyInfos, info)
+
+				w := width(m.totalCnt)
+				msgstr = fmt.Sprintf("[%*d/%*d] %s", w, info.Idx, w, m.totalCnt, msg.Message)
+
+			case json.OperationProgress:
+				loc := state.ResourceInfoLocator{
+					Module:       hook.Resource.Module,
+					ResourceAddr: hook.Resource.Addr,
+					Action:       string(hook.Action),
+				}
+				info := m.applyInfos.Find(loc)
+				if info == nil {
+					m.logger.Error("OperationProgress hook can't find the resource info", "module", hook.Resource.Module, "addr", hook.Resource.Addr, "action", hook.Action)
+					break
+				}
+
+				w := width(m.totalCnt)
+				msgstr = fmt.Sprintf("[%*d/%*d] %s", w, info.Idx, w, m.totalCnt, msg.Message)
+
+			case json.OperationComplete:
+				loc := state.ResourceInfoLocator{
+					Module:       hook.Resource.Module,
+					ResourceAddr: hook.Resource.Addr,
+					Action:       string(hook.Action),
+				}
+				status := state.ResourceStatusComplete
+				update := state.ResourceInfoUpdate{
+					Status:  &status,
+					Endtime: &msg.TimeStamp,
+				}
+				info := m.applyInfos.Update(loc, update)
+				if info == nil {
+					m.logger.Error("OperationComplete hook can't find the resource info", "module", hook.Resource.Module, "addr", hook.Resource.Addr, "action", hook.Action)
+					break
+				}
+
+				w := width(m.totalCnt)
+				msgstr = fmt.Sprintf("[%*d/%*d] %s", w, info.Idx, w, m.totalCnt, msg.Message)
+
+			case json.OperationErrored:
+				loc := state.ResourceInfoLocator{
+					Module:       hook.Resource.Module,
+					ResourceAddr: hook.Resource.Addr,
+					Action:       string(hook.Action),
+				}
+				status := state.ResourceStatusErrored
+				update := state.ResourceInfoUpdate{
+					Status:  &status,
+					Endtime: &msg.TimeStamp,
+				}
+				info := m.applyInfos.Update(loc, update)
+				if info == nil {
+					m.logger.Error("OperationErrored hook can't find the resource info", "module", hook.Resource.Module, "addr", hook.Resource.Addr, "action", hook.Action)
+					break
+				}
+
+				w := width(m.totalCnt)
+				msgstr = fmt.Sprintf("[%*d/%*d] %s", w, info.Idx, w, m.totalCnt, msg.Message)
+
+			case json.ProvisionStart:
+				msgstr = msg.Message
+			case json.ProvisionProgress:
+				msgstr = msg.Message
+			case json.ProvisionComplete:
+				msgstr = msg.Message
+			case json.ProvisionErrored:
+				msgstr = msg.Message
+			default:
+				msgstr = msg.Message
+			}
+		}
+
+		m.writer.Write([]byte(msgstr + "\n"))
+	}
+}
+
+func (m UIModel) IsEOF() bool {
+	return m.isEOF
+}
+
+func (m UIModel) ToCsv() []byte {
+	return csv.ToCsv(csv.Input{
+		RefreshInfos: m.refreshInfos,
+		ApplyInfos:   m.applyInfos,
+	})
+}
+
+func decorateMsg(level, msg string) string {
+	return msg
+}
+
+func width(n int) int {
+	var w int
+	for n != 0 {
+		n /= 10
+		w += 1
+	}
+	return w
+}

--- a/internal/state/output_info.go
+++ b/internal/state/output_info.go
@@ -1,4 +1,4 @@
-package ui
+package state
 
 import (
 	gojson "encoding/json"

--- a/internal/terraform/views/json_view_test.go
+++ b/internal/terraform/views/json_view_test.go
@@ -82,6 +82,7 @@ func TestMarshal(t *testing.T) {
   "@timestamp": "2024-12-09T10:25:00Z",
   "type": "version",
   "terraform": "1.10.0",
+  "tofu": "",
   "ui": "0.1.0"
 }
 `,


### PR DESCRIPTION
When this option is enabled, the output is simply printing human readable logs (similar to regular terraform run) to stdout. The difference is that the operation logs will be prefixed by the progress, in the form of `[idx/total]`.

## Example

```shell
$ tf apply -json -auto-approve | pipeform --plain-ui
Terraform 1.11.0-dev
[WARN] Summary: Provider development overrides are in effect. Detail: The following provider development overrides are set in the CLI configuration:
 - hashicorp/azurerm in /home/magodo/go/bin
 - magodo/restful in /home/magodo/go/bin

The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
null_resource.cluster[2]: Plan to create
null_resource.cluster[3]: Plan to create
null_resource.cluster[0]: Plan to create
null_resource.cluster[9]: Plan to create
null_resource.cluster[1]: Plan to create
null_resource.cluster[7]: Plan to create
null_resource.cluster[6]: Plan to create
null_resource.cluster[8]: Plan to create
null_resource.cluster[4]: Plan to create
null_resource.cluster[5]: Plan to create
Plan: 10 to add, 0 to change, 0 to destroy.
Outputs: 3.
[ 1/10] null_resource.cluster[8]: Creating...
[ 2/10] null_resource.cluster[3]: Creating...
[ 3/10] null_resource.cluster[0]: Creating...
[ 4/10] null_resource.cluster[6]: Creating...
[ 5/10] null_resource.cluster[1]: Creating...
[ 6/10] null_resource.cluster[5]: Creating...
[ 7/10] null_resource.cluster[4]: Creating...
[ 8/10] null_resource.cluster[2]: Creating...
[ 9/10] null_resource.cluster[9]: Creating...
[10/10] null_resource.cluster[7]: Creating...
null_resource.cluster[8]: Provisioning with 'local-exec'...
null_resource.cluster[6]: Provisioning with 'local-exec'...
null_resource.cluster[8]: (local-exec): Executing: ["/bin/sh" "-c" "sleep 4"]
null_resource.cluster[1]: Provisioning with 'local-exec'...
null_resource.cluster[6]: (local-exec): Executing: ["/bin/sh" "-c" "sleep 2"]
null_resource.cluster[3]: Provisioning with 'local-exec'...
null_resource.cluster[2]: Provisioning with 'local-exec'...
null_resource.cluster[0]: Provisioning with 'local-exec'...
null_resource.cluster[2]: (local-exec): Executing: ["/bin/sh" "-c" "sleep 3"]
null_resource.cluster[4]: Provisioning with 'local-exec'...
null_resource.cluster[3]: (local-exec): Executing: ["/bin/sh" "-c" "sleep 4"]
null_resource.cluster[5]: Provisioning with 'local-exec'...
null_resource.cluster[7]: Provisioning with 'local-exec'...
null_resource.cluster[1]: (local-exec): Executing: ["/bin/sh" "-c" "sleep 2"]
null_resource.cluster[0]: (local-exec): Executing: ["/bin/sh" "-c" "sleep 1"]
null_resource.cluster[4]: (local-exec): Executing: ["/bin/sh" "-c" "sleep 5"]
null_resource.cluster[9]: Provisioning with 'local-exec'...
null_resource.cluster[9]: (local-exec): Executing: ["/bin/sh" "-c" "sleep 5"]
null_resource.cluster[5]: (local-exec): Executing: ["/bin/sh" "-c" "sleep 1"]
null_resource.cluster[7]: (local-exec): Executing: ["/bin/sh" "-c" "sleep 3"]
null_resource.cluster[0]: (local-exec) Provisioning complete
[ 3/10] null_resource.cluster[0]: Creation complete after 1s [id=8407573660303856038]
null_resource.cluster[5]: (local-exec) Provisioning complete
[ 6/10] null_resource.cluster[5]: Creation complete after 1s [id=826303085593348667]
null_resource.cluster[1]: (local-exec) Provisioning complete
[ 5/10] null_resource.cluster[1]: Creation complete after 2s [id=85940904527369560]
null_resource.cluster[6]: (local-exec) Provisioning complete
[ 4/10] null_resource.cluster[6]: Creation complete after 2s [id=1437207670017410036]
null_resource.cluster[7]: (local-exec) Provisioning complete
[10/10] null_resource.cluster[7]: Creation complete after 3s [id=4686925934119204217]
null_resource.cluster[2]: (local-exec) Provisioning complete
[ 8/10] null_resource.cluster[2]: Creation complete after 3s [id=5292073499372246394]
null_resource.cluster[8]: (local-exec) Provisioning complete
[ 1/10] null_resource.cluster[8]: Creation complete after 4s [id=6110374286473418234]
null_resource.cluster[3]: (local-exec) Provisioning complete
[ 2/10] null_resource.cluster[3]: Creation complete after 4s [id=2143941884576965972]
null_resource.cluster[4]: (local-exec) Provisioning complete
[ 7/10] null_resource.cluster[4]: Creation complete after 5s [id=853459480431937552]
null_resource.cluster[9]: (local-exec) Provisioning complete
[ 9/10] null_resource.cluster[9]: Creation complete after 5s [id=1723593824438847119]
Apply complete! Resources: 10 added, 0 changed, 0 destroyed.
Outputs: 3. output_num=123 output_string="8407573660303856038" output_bool=true
```